### PR TITLE
encode to bytes to run with pyserial 3.5

### DIFF
--- a/lw20_python_serial/lw20_python_serial.py
+++ b/lw20_python_serial/lw20_python_serial.py
@@ -21,18 +21,18 @@ serialPortBaudRate = 115200
 port = serial.Serial(serialPortName, serialPortBaudRate, timeout=0.1)
 
 # Enable serial mode by sending some characters over the serial port.
-port.write('www\r\n')
+port.write(bytes('www\r\n','ascii'))
 # Read and ignore any unintended responses
 port.readline()
 
 # Get the product information
-port.write('?\r\n')
+port.write(bytes('?\r\n','ascii'))
 productInfo = port.readline()
-print('Product information: ' + productInfo)
+print('Product information: ' + productInfo.decode('ascii'))
 
-while True:	
+while True:
 	# Get distance reading (First return, default filtering)
-	port.write('LD\r\n')
+	port.write(bytes('LD\r\n','ascii'))
 	distanceStr = port.readline()
 	# Convert the distance string response into a number
 	distanceCM = float(distanceStr) * 100


### PR DESCRIPTION
I'm running python3.9 and pyserial 3.5, the code would not work, failing with error:
```
File "LightWare/lw20_python_serial/lw20_python_serial.py", line 24, in <module>
    port.write('www\r\n')
File "/usr/local/lib/python3.9/site-packages/pyserial-3.5-py3.9.egg/serial/serialposix.py", line 616, in write
    d = to_bytes(data)
File "/usr/local/lib/python3.9/site-packages/pyserial-3.5-py3.9.egg/serial/serialutil.py", line 65, in to_bytes
    raise TypeError('unicode strings are not supported, please encode to bytes: {!r}'.format(seq))
TypeError: unicode strings are not supported, please encode to bytes: 'www\r\n'
```
The changes in this pull request fixed the issue. 